### PR TITLE
fix for nginx 1.25.5+

### DIFF
--- a/src/ngx_stream_preread_str_module.c
+++ b/src/ngx_stream_preread_str_module.c
@@ -140,7 +140,7 @@ ngx_stream_preread_str_preread_handler(ngx_stream_session_t *s)
 #if defined(nginx_version) && nginx_version >= 1025005
     /* consume the data from the socket */
     size = ctx->header.len + pscf->delim.len;
-    if (c->recv(c, c->buffer->start, size) != (ssize_t) size) {
+    if (c->recv(c, ctx->header.data, size) != (ssize_t) size) {
         return NGX_STREAM_INTERNAL_SERVER_ERROR;
     }
 #endif

--- a/src/ngx_stream_preread_str_module.c
+++ b/src/ngx_stream_preread_str_module.c
@@ -73,6 +73,37 @@ static ngx_stream_variable_t  ngx_stream_preread_str_vars[] = {
 };
 
 
+#if defined(nginx_version) && nginx_version >= 1025005
+static ngx_uint_t
+ngx_stream_preread_can_peek(ngx_connection_t *c)
+{
+#if (NGX_STREAM_SSL)
+    if (c->ssl) {
+        return 0;
+    }
+#endif
+
+    if ((ngx_event_flags & NGX_USE_CLEAR_EVENT) == 0) {
+        return 0;
+    }
+
+#if (NGX_HAVE_KQUEUE)
+    if (ngx_event_flags & NGX_USE_KQUEUE_EVENT) {
+        return 1;
+    }
+#endif
+
+#if (NGX_HAVE_EPOLLRDHUP)
+    if ((ngx_event_flags & NGX_USE_EPOLL_EVENT) && ngx_use_epoll_rdhup) {
+        return 1;
+    }
+#endif
+
+    return 0;
+}
+#endif
+
+
 static ngx_int_t
 ngx_stream_preread_str_preread_handler(ngx_stream_session_t *s)
 {
@@ -138,6 +169,10 @@ ngx_stream_preread_str_preread_handler(ngx_stream_session_t *s)
     c->buffer->pos = ctx->pos + s2_len;
 
 #if defined(nginx_version) && nginx_version >= 1025005
+    if (!ngx_stream_preread_can_peek(c)) {
+        return NGX_OK;
+    }
+
     /* consume the data from the socket */
     size = ctx->header.len + pscf->delim.len;
     if (c->recv(c, ctx->header.data, size) != (ssize_t) size) {


### PR DESCRIPTION
starting nginx 1.25.5, nginx stream uses MSG_PEEK for PREREAD phase, so any data consumed by this module is seen by the content phase handler. issue another call to recv in order to consume this data, and hide it from the content handler.