### PR TITLE
fix NGX_AGAIN error from c->recv after peek

### DIFF
--- a/src/ngx_stream_preread_str_module.c
+++ b/src/ngx_stream_preread_str_module.c
@@ -175,7 +175,7 @@ ngx_stream_preread_str_preread_handler(ngx_stream_session_t *s)
 
     /* consume the data from the socket */
     size = ctx->header.len + pscf->delim.len;
-    if (c->recv(c, ctx->header.data, size) != (ssize_t) size) {
+    if (recv(c->fd, ctx->header.data, size, 0) != (ssize_t) size) {
         return NGX_STREAM_INTERNAL_SERVER_ERROR;
     }
 #endif


### PR DESCRIPTION
in some cases (e.g. local proxy) the data is available on the socket immediately, ngx_stream runs the preread phase and calls our handler. in this case, r->read->available still has its original zero value (it is reset in ngx_get_connection). since available is zero, ngx_unix_recv returns NGX_AGAIN immediately, without even calling recv. the fix is to avoid using c->recv in this case, and call the operating system's recv function directly.